### PR TITLE
Alternative solution for #6

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -1218,6 +1218,8 @@ graph.prototype.get_child_nodes = function(nb_id, in_pred){
 };
 
 /**
+ * Walk a graph from subject to object (if subject2object === true) or from object to subject otherwise.
+ *
  * Return a list with two nested lists, the first is a list of nodes,
  * the second is a list of edges.
  *
@@ -1226,10 +1228,11 @@ graph.prototype.get_child_nodes = function(nb_id, in_pred){
  *
  * @param {Function} walking_fun - function as described above
  * @param {String|Array} nb_id_or_list - the node id(s) to consider
+ * @param {Boolean} subject2object - walking direction => from subject to object (if subject2object === true) or from object to subject otherwise
  * @param {String} pid - (optional) over this predicate
  * @returns {Array} as described above
  */
-graph.prototype.walker = function(walking_fun, nb_id_or_list, pid){
+graph.prototype.walker = function(walking_fun, nb_id_or_list, subject2object, pid){
     var anchor = this;
     
     // Shared data structure to trim multiple paths.
@@ -1258,8 +1261,21 @@ graph.prototype.walker = function(walking_fun, nb_id_or_list, pid){
 	// get_parent_edges (as all this is now implemented).
 	var new_area_nodes = [];
 	each(new_area_edges, function(edge){
-	    // We add the node with id different from `nid`, it might
-        // be object or subject depending on walking_fun
+	    if (subject2object) {
+            var target_id = edge.object_id()
+        }
+        else {
+            var target_id = edge.subject_id();
+        }
+        // Extra error handling, could be removed
+        if (target_id === nid)
+        {
+            if (edge.object_id() === edge.subject_id())
+            {
+                throw new Error('self-referencing is not supported by walker, leads to infinite loop.')
+            }
+            throw new Error(`if subject2object === ${subject2object} function 'walking_fun' should return a node's ${subject2object ? 'object' : 'target'}`)
+        }
 	    var target_id = edge.object_id() !== nid ? edge.object_id() : edge.subject_id();
         var temp_node = anchor.get_node(target_id);
 	    if( temp_node ){
@@ -1315,7 +1331,7 @@ graph.prototype.get_ancestor_subgraph = function(nb_id_or_list, pid){
     var anchor = this;
 
     var walk_results = 
-	anchor.walker(anchor.get_parent_edges, nb_id_or_list, pid);
+	anchor.walker(anchor.get_parent_edges, nb_id_or_list, true, pid);
     var walked_nodes = walk_results[0];
     var walked_edges = walk_results[1];
     
@@ -1344,7 +1360,7 @@ graph.prototype.get_descendent_subgraph = function(nb_id_or_list, pid){
     var anchor = this;
 
     var walk_results = 
-	anchor.walker(anchor.get_child_edges, nb_id_or_list, pid);
+	anchor.walker(anchor.get_child_edges, nb_id_or_list, false, pid);
     var walked_nodes = walk_results[0];
     var walked_edges = walk_results[1];
     

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -1258,9 +1258,10 @@ graph.prototype.walker = function(walking_fun, nb_id_or_list, pid){
 	// get_parent_edges (as all this is now implemented).
 	var new_area_nodes = [];
 	each(new_area_edges, function(edge){
-	    // Make sure that any found edges are in our world.
-	    var obj_id = edge.object_id();
-	    var temp_node = anchor.get_node(obj_id);
+	    // We add the node with id different from `nid`, it might
+        // be object or subject depending on walking_fun
+	    var target_id = edge.object_id() !== nid ? edge.object_id() : edge.subject_id();
+        var temp_node = anchor.get_node(target_id);
 	    if( temp_node ){
 		new_area_nodes.push( temp_node );
 	    }


### PR DESCRIPTION
Hello @kltm this is an alternative solution to avoid code duplication. It also handles some errors (self-referencing relationships should not be allowed + returns error if waling_fun returns the same id passed as object)

https://github.com/manulera/bbop-graph/blob/079aa824970320768465d26c28e0993cccd314f9/lib/graph.js#L1264-L1278

I tried to write a test, but I can't get the gulp scripts to run locally. If you add instructions of installation (node version where it works, etc.), I can add them. Otherwise, here is a script to test that it does what it should, if you create it in the root dir:

```js

const library = require('./lib/graph')

async function main() {

    const go_resp = await fetch(
        "http://current.geneontology.org/ontology/go.json"
    );
    const go_json = await go_resp.json()
    const g = new library.graph();
    g.load_base_json(go_json.graphs[0])

    console.log('total nodes:',g.all_nodes().length)

    var anc = g.get_ancestor_subgraph('http://purl.obolibrary.org/obo/GO_0006366');
    console.log('number of ancestors:',anc.all_nodes().length);

    var des = g.get_descendent_subgraph('http://purl.obolibrary.org/obo/GO_0006366');
    console.log('number of descendents:',des.all_nodes().length);

    const walker_right = g.walker(g.get_child_edges, 'http://purl.obolibrary.org/obo/GO_0006366', false);
    console.log('should match number of ancestors:', walker_right[0].length)

    // Should throw an error
    g.walker(g.get_child_edges, 'http://purl.obolibrary.org/obo/GO_0006366', true);
}

main()
```